### PR TITLE
Enable RBD/CephFS CSI drivers via Helm values

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -107,6 +107,8 @@ parameters:
       tolerations: ${rook_ceph:tolerations}
       csi:
         enableCSIHostNetwork: false
+        enableRbdDriver: ${rook_ceph:ceph_cluster:rbd_enabled}
+        enableCephfsDriver: ${rook_ceph:ceph_cluster:cephfs_enabled}
         cephcsi:
           image: ${rook_ceph:images:cephcsi:registry}/${rook_ceph:images:cephcsi:image}:${rook_ceph:images:cephcsi:tag}
 

--- a/postprocess/patch_operator_deployment.jsonnet
+++ b/postprocess/patch_operator_deployment.jsonnet
@@ -27,15 +27,7 @@ local deployment = com.yaml_load(deployment_file) + {
           if c.name == 'rook-ceph-operator' then
             c {
               env: [
-                if e.name == 'ROOK_CSI_ENABLE_RBD' then
-                  e {
-                    value: '%s' % params.ceph_cluster.rbd_enabled,
-                  }
-                else if e.name == 'ROOK_CSI_ENABLE_CEPHFS' then
-                  e {
-                    value: '%s' % params.ceph_cluster.cephfs_enabled,
-                  }
-                else if e.name == 'ROOK_HOSTPATH_REQUIRES_PRIVILEGED' then
+                if e.name == 'ROOK_HOSTPATH_REQUIRES_PRIVILEGED' then
                   e {
                     value: '%s' % hostpath_requires_privileged,
                   }


### PR DESCRIPTION
Not necessary to do this in postprocessing, as the Helm chart provides values for it.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
