### PR TITLE
Enable removeOSDsIfOutAndSafeToRemove by default

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -188,6 +188,8 @@ parameters:
                       storage: ${rook_ceph:ceph_cluster:block_volume_size}
             encrypted: true
             tuneFastDeviceClass: ${rook_ceph:ceph_cluster:tune_fast_device_class}
+      # Automatically remove OSDs that are down and whose data has been moved to other OSDs
+      removeOSDsIfOutAndSafeToRemove: true
 
       disruptionManagement:
         managePodBudgets: true


### PR DESCRIPTION
This configures the operator to remove OSD deployments for OSDs that are
down and whose data has been moved to other OSDs.

This removes the need to manually delete OSD deployments when replacing
disks/nodes.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [ ] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation.
- [ ] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
