### PR TITLE
Configure CephCluster full ratios to match alerts

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -15,6 +15,17 @@ parameters:
       tune_fast_device_class: false
       # Rendered into rook-config-override CM
       config_override:
+        global:
+          # Configure full ratios to match the alerts shipped with Rook.
+          # With this config the cluster goes readonly at 85% utilization.
+          # These configs only apply at cluster creation.
+          # To adjust the ratios at run time, use
+          #   `ceph osd set-{nearfull,backfillfull,full}-ratio`
+          # NOTE: we're giving ratios as strings to avoid float rounding
+          # issues when manifesting the values in the resulting config file.
+          mon_osd_full_ratio: '0.85'
+          mon_osd_backfillfull_ratio: '0.8'
+          mon_osd_nearfull_ratio: '0.75'
         osd:
           # We explicitly set bluefs_buffered_io to false to get good write
           # bandwidth on Exoscale -> TODO: needs to be checked per

--- a/docs/modules/ROOT/pages/how-tos/configure-ceph.adoc
+++ b/docs/modules/ROOT/pages/how-tos/configure-ceph.adoc
@@ -71,3 +71,40 @@ parameters:
 As discussed in xref:references/parameters.adoc#_config_override[the parameter's documentation], the contents of `ceph_cluster.config_override` are rendered into __ini__ style format by the component.
 
 Each key in the parameter is used as the name of a section in the resulting _ini_ style configuration file.
+
+== Configure Ceph full ratios
+
+Ceph has https://docs.ceph.com/en/latest/rados/configuration/mon-config-ref/#storage-capacity[configuration options] to control at which point the cluster starts warning about potential service interruptions due to running out of disk space.
+
+The component sets the config options `mon_osd_full_ratio=0.85`, `mon_osd_backfillfull_ratio=0.8` and `mon_osd_nearfull_ratio=0.75` in the Rook `config-override` configmap.
+With this configuration, the Ceph cluster will go into read-only mode when it's utilized to 85% of its capacity.
+
+You can tune these options before creating the Ceph cluster by providing the following config.
+
+[source,yaml]
+----
+parameters:
+  rook_ceph:
+    ceph_cluster:
+      config_override:
+        global:
+          mon_osd_full_ratio: '0.9' <1>
+          mon_osd_nearfull_ratio: '0.8' <2>
+          mon_osd_backfillfull_ratio: '0.85' <3>
+----
+<1> Configure the cluster to become read-only (OSD status `full`) at 90% utilization.
+We give the ratios as strings to avoid the resulting configuration containing values like `0.90000000000000002` due to floating point rounding issues.
+<2> Configure the threshold at which the OSD status becomes `nearfull`.
+<3> Configure the threshold at which Ceph won't backfill more data to the OSD.
+
+At runtime, you can adjust the cluster's ratios with
+
+[source,bash]
+----
+kubectl --as=cluster-admin exec -it deploy/rook-ceph-tools -- ceph osd set-full-ratio 0.9 <1>
+kubectl --as=cluster-admin exec -it deploy/rook-ceph-tools -- ceph osd set-nearfull-ratio 0.8 <2>
+kubectl --as=cluster-admin exec -it deploy/rook-ceph-tools -- ceph osd set-backfillfull-ratio 0.85 <3>
+----
+<1> Configure the cluster to become read-only (OSD status `full`) at 90% utilization.
+<2> Configure the threshold at which the OSD status becomes `nearfull`.
+<3> Configure the threshold at which Ceph won't backfill more data to the OSD.

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -85,6 +85,10 @@ default::
 +
 [source,yaml]
 ----
+global:
+  mon_osd_full_ratio: '0.85'
+  mon_osd_backfillfull_ratio: '0.8'
+  mon_osd_nearfull_ratio: '0.75'
 osd:
   bluefs_buffered_io: false
 ----
@@ -99,10 +103,21 @@ Please be aware that Ceph may fail to start if you provide an invalid configurat
 See the https://docs.ceph.com/en/latest/rados/configuration/ceph-conf/[Ceph documentation] for a list of valid configuration sections and options.
 ====
 
+[TIP]
+====
+Use strings to represent fractional values in `config_override`.
+Otherwise, the rendered values in the _ini_ style file may suffer from floating point rounding issues.
+For example, if the fractional value `0.8` is given as a number in YAML, it would be rendered as `0.80000000000000004` in the resulting _ini_ style file.
+====
+
 The default value is translated into the following _ini_ style file:
 
 [source,ini]
 ----
+[global]
+mon_osd_full_ratio = 0.85
+mon_osd_backfillfull_ratio = 0.8
+mon_osd_nearfull_ratio = 0.75
 [osd]
 bluefs_buffered_io = false
 ----


### PR DESCRIPTION
The alerts shipped with Rook alert on the assumption that the cluster becomes read-only (OSD status `full`) at 85% capacity. However, by default, ceph configures the cluster's `full-ratio` at 95% capacity.

This commit adjusts the default full ratios to match the alerts we put in place.

Please note that the ratios configured in `config_override.global` only apply during Ceph cluster creation. To adjust the ratios at runtime, use `ceph osd set-{nearfull,backfillfull,full}-ratio <ratio>` in the `rook-ceph-tools` container on the cluster

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
