### PR TITLE
Remove `osd.bluefs_buffered_io=false` from the default config

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -31,11 +31,6 @@ parameters:
           mon_osd_full_ratio: '0.85'
           mon_osd_backfillfull_ratio: '0.8'
           mon_osd_nearfull_ratio: '0.75'
-        osd:
-          # We explicitly set bluefs_buffered_io to false to get good write
-          # bandwidth on Exoscale -> TODO: needs to be checked per
-          # infrastructure, maybe move the config to cloud/exoscale/params.yml
-          bluefs_buffered_io: false
 
       # Whether to setup RBD CSI driver and pools
       rbd_enabled: true

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -113,8 +113,6 @@ global:
   mon_osd_full_ratio: '0.85'
   mon_osd_backfillfull_ratio: '0.8'
   mon_osd_nearfull_ratio: '0.75'
-osd:
-  bluefs_buffered_io: false
 ----
 
 Additional Ceph configurations which are rendered in _ini_ style format by the component.
@@ -142,8 +140,6 @@ The default value is translated into the following _ini_ style file:
 mon_osd_full_ratio = 0.85
 mon_osd_backfillfull_ratio = 0.8
 mon_osd_nearfull_ratio = 0.75
-[osd]
-bluefs_buffered_io = false
 ----
 
 The resulting _ini_ style file is written to the ConfigMap `rook-config-override` in the Ceph cluster namespace.


### PR DESCRIPTION
This is not required on all clouds and actually causes repeated OSD crashes on cloudscale.ch on CSI-provisioned volumeMode=Block PVCs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog


<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
