### PR TITLE
Rename the helm chart release_name variable for Kapitan to name

### DIFF
--- a/class/rook-ceph.yml
+++ b/class/rook-ceph.yml
@@ -36,7 +36,7 @@ parameters:
         output_path: rook-ceph/01_rook_ceph_helmchart
         helm_values: ${rook_ceph:operator_helm_values}
         helm_params:
-          release_name: syn-rook-ceph
+          name: syn-rook-ceph
           namespace: ${rook_ceph:namespace}
       - input_paths:
           - rook-ceph/component/main.jsonnet


### PR DESCRIPTION
Kapitan has changed the helm chart naming and release_name is
now deprecated.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

