### PR TITLE
Add ClusterRoles to grant access to Rook-Ceph custom resources via aggregated ClusterRoles

### DIFF
--- a/component/aggregated_rbac.libsonnet
+++ b/component/aggregated_rbac.libsonnet
@@ -1,0 +1,97 @@
+local kube = import 'lib/kube.libjsonnet';
+
+local custom_resources = [
+  {
+    apiGroups: [ 'ceph.rook.io' ],
+    resources: [
+      'cephblockpoolradosnamespaces',
+      'cephblockpools',
+      'cephbucketnotifications',
+      'cephbuckettopics',
+      'cephclients',
+      'cephclusters',
+      'cephfilesystemmirrors',
+      'cephfilesystems',
+      'cephfilesystemsubvolumegroups',
+      'cephnfss',
+      'cephobjectrealms',
+      'cephobjectstores',
+      'cephobjectstoreusers',
+      'cephobjectzonegroups',
+      'cephobjectzones',
+      'cephrbdmirrors',
+    ],
+  },
+  {
+    apiGroups: [ 'objectbucket.io' ],
+    resources: [
+      'objectbucketclaims',
+      // objectbuckets are cluster-scoped, see below
+    ],
+  },
+];
+
+local verbs = {
+  'rook-ceph-view': [
+    'get',
+    'list',
+    'watch',
+  ],
+  'rook-ceph-edit': [
+    'create',
+    'delete',
+    'deletecollection',
+    'patch',
+    'update',
+  ],
+};
+
+local cluster_roles =
+  [
+    kube.ClusterRole(name) {
+      metadata+: {
+        labels+:
+          {
+            'rbac.authorization.k8s.io/aggregate-to-admin': 'true',
+            'rbac.authorization.k8s.io/aggregate-to-edit': 'true',
+          } +
+          if name == 'rook-ceph-view' then
+            {
+              'rbac.authorization.k8s.io/aggregate-to-view': 'true',
+            }
+          else {},
+      },
+      rules: [
+        cr {
+          verbs: verbs[name],
+        }
+        for cr in custom_resources
+      ],
+    }
+    for name in [ 'rook-ceph-view', 'rook-ceph-edit' ]
+  ] +
+  [
+    // Only aggregate view permissions for objectbuckets which are
+    // cluster-scoped to cluster-reader.
+    // This may not work out of the box on K8s distributions other than
+    // OpenShift 4.
+    kube.ClusterRole('rook-ceph-cluster-reader') {
+      metadata+: {
+        labels+: {
+          'rbac.authorization.k8s.io/aggregate-to-cluster-reader': 'true',
+        },
+      },
+      rules: [
+        {
+          apiGroups: [ 'objectbucket.io' ],
+          resources: [ 'objectbuckets' ],
+          verbs: verbs['rook-ceph-view'],
+        },
+      ],
+    },
+  ];
+
+
+{
+  cluster_roles: cluster_roles,
+}

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -35,6 +35,8 @@ local csi_metrics = import 'csi_metrics.libsonnet';
 
 local alert_rules = import 'alertrules.libsonnet';
 
+local aggregated_rbac = import 'aggregated_rbac.libsonnet';
+
 local namespaces =
   [
     kube.Namespace(params.namespace) + ns_config,
@@ -72,6 +74,7 @@ std.mapWithKey(
       },
   {
     '00_namespaces': namespaces,
+    '01_aggregated_rbac': aggregated_rbac.cluster_roles,
     [if on_openshift then '02_openshift_sccs']: ocp_config.sccs,
     '10_cephcluster_rbac': cephcluster.rbac,
     '10_cephcluster_configoverride': cephcluster.configmap,

--- a/tests/golden/defaults/rook-ceph/rook-ceph/01_aggregated_rbac.yaml
+++ b/tests/golden/defaults/rook-ceph/rook-ceph/01_aggregated_rbac.yaml
@@ -1,0 +1,115 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: rook-ceph
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: rook-ceph-view
+    name: rook-ceph-view
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+    rbac.authorization.k8s.io/aggregate-to-view: 'true'
+  name: rook-ceph-view
+rules:
+  - apiGroups:
+      - ceph.rook.io
+    resources:
+      - cephblockpoolradosnamespaces
+      - cephblockpools
+      - cephbucketnotifications
+      - cephbuckettopics
+      - cephclients
+      - cephclusters
+      - cephfilesystemmirrors
+      - cephfilesystems
+      - cephfilesystemsubvolumegroups
+      - cephnfss
+      - cephobjectrealms
+      - cephobjectstores
+      - cephobjectstoreusers
+      - cephobjectzonegroups
+      - cephobjectzones
+      - cephrbdmirrors
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - objectbucket.io
+    resources:
+      - objectbucketclaims
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: rook-ceph
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: rook-ceph-edit
+    name: rook-ceph-edit
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+  name: rook-ceph-edit
+rules:
+  - apiGroups:
+      - ceph.rook.io
+    resources:
+      - cephblockpoolradosnamespaces
+      - cephblockpools
+      - cephbucketnotifications
+      - cephbuckettopics
+      - cephclients
+      - cephclusters
+      - cephfilesystemmirrors
+      - cephfilesystems
+      - cephfilesystemsubvolumegroups
+      - cephnfss
+      - cephobjectrealms
+      - cephobjectstores
+      - cephobjectstoreusers
+      - cephobjectzonegroups
+      - cephobjectzones
+      - cephrbdmirrors
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update
+  - apiGroups:
+      - objectbucket.io
+    resources:
+      - objectbucketclaims
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: rook-ceph
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: rook-ceph-cluster-reader
+    name: rook-ceph-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: rook-ceph-cluster-reader
+rules:
+  - apiGroups:
+      - objectbucket.io
+    resources:
+      - objectbuckets
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/openshift4/rook-ceph/rook-ceph/01_aggregated_rbac.yaml
+++ b/tests/golden/openshift4/rook-ceph/rook-ceph/01_aggregated_rbac.yaml
@@ -1,0 +1,115 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: rook-ceph
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: rook-ceph-view
+    name: rook-ceph-view
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+    rbac.authorization.k8s.io/aggregate-to-view: 'true'
+  name: rook-ceph-view
+rules:
+  - apiGroups:
+      - ceph.rook.io
+    resources:
+      - cephblockpoolradosnamespaces
+      - cephblockpools
+      - cephbucketnotifications
+      - cephbuckettopics
+      - cephclients
+      - cephclusters
+      - cephfilesystemmirrors
+      - cephfilesystems
+      - cephfilesystemsubvolumegroups
+      - cephnfss
+      - cephobjectrealms
+      - cephobjectstores
+      - cephobjectstoreusers
+      - cephobjectzonegroups
+      - cephobjectzones
+      - cephrbdmirrors
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - objectbucket.io
+    resources:
+      - objectbucketclaims
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: rook-ceph
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: rook-ceph-edit
+    name: rook-ceph-edit
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+  name: rook-ceph-edit
+rules:
+  - apiGroups:
+      - ceph.rook.io
+    resources:
+      - cephblockpoolradosnamespaces
+      - cephblockpools
+      - cephbucketnotifications
+      - cephbuckettopics
+      - cephclients
+      - cephclusters
+      - cephfilesystemmirrors
+      - cephfilesystems
+      - cephfilesystemsubvolumegroups
+      - cephnfss
+      - cephobjectrealms
+      - cephobjectstores
+      - cephobjectstoreusers
+      - cephobjectzonegroups
+      - cephobjectzones
+      - cephrbdmirrors
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update
+  - apiGroups:
+      - objectbucket.io
+    resources:
+      - objectbucketclaims
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: rook-ceph
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: rook-ceph-cluster-reader
+    name: rook-ceph-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: rook-ceph-cluster-reader
+rules:
+  - apiGroups:
+      - objectbucket.io
+    resources:
+      - objectbuckets
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
Most Rook-Ceph custom resources are namespaced, so users still need to be able to access the namespace to interact with the resources

We explicitly only aggregate view permissions for the cluster-scoped `ObjectBucket` resources to ClusterRole `cluster-reader`, which is always present on OpenShift 4, and can be setup on other distributions if desired.

Closes #34




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
