### PR TITLE
Allow CSI provisioner pods to be scheduled on the storage nodes

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -163,6 +163,7 @@ parameters:
           memory: 512Mi
       tolerations: ${rook_ceph:tolerations}
       csi:
+        provisionerTolerations: ${rook_ceph:tolerations}
         enableCSIHostNetwork: false
         enableRbdDriver: ${rook_ceph:ceph_cluster:rbd_enabled}
         enableCephfsDriver: ${rook_ceph:ceph_cluster:cephfs_enabled}

--- a/tests/golden/defaults/rook-ceph/rook-ceph/01_rook_ceph_helmchart/rook-ceph/templates/configmap.yaml
+++ b/tests/golden/defaults/rook-ceph/rook-ceph/01_rook_ceph_helmchart/rook-ceph/templates/configmap.yaml
@@ -41,6 +41,7 @@ data:
   CSI_PLUGIN_PRIORITY_CLASSNAME: system-node-critical
   CSI_PROVISIONER_PRIORITY_CLASSNAME: system-cluster-critical
   CSI_PROVISIONER_REPLICAS: '2'
+  CSI_PROVISIONER_TOLERATIONS: "- key: storagenode\n  operator: Exists"
   CSI_RBD_FSGROUPPOLICY: ReadWriteOnceWithFSType
   CSI_RBD_PLUGIN_RESOURCE: "- name : driver-registrar\n  resource:\n    requests:\n\
     \      memory: 128Mi\n      cpu: 50m\n    limits:\n      memory: 256Mi\n     \

--- a/tests/golden/openshift4/rook-ceph/rook-ceph/01_rook_ceph_helmchart/rook-ceph/templates/configmap.yaml
+++ b/tests/golden/openshift4/rook-ceph/rook-ceph/01_rook_ceph_helmchart/rook-ceph/templates/configmap.yaml
@@ -41,6 +41,7 @@ data:
   CSI_PLUGIN_PRIORITY_CLASSNAME: system-node-critical
   CSI_PROVISIONER_PRIORITY_CLASSNAME: system-cluster-critical
   CSI_PROVISIONER_REPLICAS: '2'
+  CSI_PROVISIONER_TOLERATIONS: "- key: storagenode\n  operator: Exists"
   CSI_RBD_FSGROUPPOLICY: ReadWriteOnceWithFSType
   CSI_RBD_PLUGIN_RESOURCE: "- name : driver-registrar\n  resource:\n    requests:\n\
     \      memory: 128Mi\n      cpu: 50m\n    limits:\n      memory: 256Mi\n     \


### PR DESCRIPTION
We need to configure tolerations for the provisioner pods to allow them to be scheduled on the storage nodes. Currently the provisioner pods are always scheduled elsewhere, because they don't tolerate the storage node taint.



## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
