### PR TITLE
Allow the default SA in the operator namespace to use the Ceph-CSI SCC

### DIFF
--- a/component/openshift.libsonnet
+++ b/component/openshift.libsonnet
@@ -44,6 +44,11 @@ local patches = {
         'rook-csi-rbd-provisioner-sa',
         'rook-csi-cephfs-plugin-sa',
         'rook-csi-cephfs-provisioner-sa',
+        // Rook v1.9 adds "holder" DaemonSets for the CSI plugins which run
+        // with the default serviceaccount, so we need to also allow the
+        // default serviceaccount in the namespace access to the rook-ceph-csi
+        // SCC.
+        'default',
       ], params.namespace),
   },
 };

--- a/tests/golden/openshift4/rook-ceph/rook-ceph/02_openshift_sccs.yaml
+++ b/tests/golden/openshift4/rook-ceph/rook-ceph/02_openshift_sccs.yaml
@@ -71,6 +71,7 @@ users:
   - system:serviceaccount:syn-rook-ceph-operator:rook-csi-rbd-provisioner-sa
   - system:serviceaccount:syn-rook-ceph-operator:rook-csi-cephfs-plugin-sa
   - system:serviceaccount:syn-rook-ceph-operator:rook-csi-cephfs-provisioner-sa
+  - system:serviceaccount:syn-rook-ceph-operator:default
 volumes:
   - configMap
   - emptyDir


### PR DESCRIPTION
This is required for Rook 1.9+ because new DaemonSets which manage the CSI driver's network namespace have been added in Rook 1.9. These DaemonSets run with the default ServiceAccount (this is currently not configurable), so we need to grant the default SA access to the Ceph-CSI SCC to allow those DaemonSet pods to be created on OpenShift 4.

See also https://github.com/rook/rook/pull/9643 and related implementation PRs

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
