### PR TITLE
Tune default resource requests

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -215,11 +215,11 @@ parameters:
       resources:
         mgr:
           limits:
-            cpu: "1"
-            memory: 2Gi
+            cpu: "500m"
+            memory: "1Gi"
           requests:
-            cpu: "1"
-            memory: 2Gi
+            cpu: "250m"
+            memory: "512Mi"
         mon:
           limits:
             cpu: "1"

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -100,10 +100,10 @@ parameters:
                 resources:
                   requests:
                     cpu: "1"
-                    memory: 8Gi
+                    memory: 4Gi
                   limits:
                     cpu: "1"
-                    memory: 8Gi
+                    memory: 4Gi
                 # metadata server placement done in Jsonnet but can be
                 # extended here
               mirroring:

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -222,10 +222,10 @@ parameters:
             memory: "512Mi"
         mon:
           limits:
-            cpu: "1"
+            cpu: "500m"
             memory: 2Gi
           requests:
-            cpu: "1"
+            cpu: "250m"
             memory: 2Gi
         osd:
           limits:

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -229,10 +229,10 @@ parameters:
             memory: 2Gi
         osd:
           limits:
-            cpu: "6"
+            cpu: "2"
             memory: 5Gi
           requests:
-            cpu: "4"
+            cpu: "2"
             memory: 5Gi
       storage:
         useAllNodes: false

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -313,10 +313,10 @@ fspool:
       resources:
         requests:
           cpu: "1"
-          memory: 8Gi
+          memory: 4Gi
         limits:
           cpu: "1"
-          memory: 8Gi
+          memory: 4Gi
       # metadata server placement done in Jsonnet but can be
       # extended here
     mirroring:

--- a/tests/golden/defaults/rook-ceph/rook-ceph/10_cephcluster_cluster.yaml
+++ b/tests/golden/defaults/rook-ceph/rook-ceph/10_cephcluster_cluster.yaml
@@ -54,10 +54,10 @@ spec:
         memory: 2Gi
     osd:
       limits:
-        cpu: '6'
+        cpu: '2'
         memory: 5Gi
       requests:
-        cpu: '4'
+        cpu: '2'
         memory: 5Gi
   storage:
     storageClassDeviceSets:

--- a/tests/golden/defaults/rook-ceph/rook-ceph/10_cephcluster_cluster.yaml
+++ b/tests/golden/defaults/rook-ceph/rook-ceph/10_cephcluster_cluster.yaml
@@ -47,10 +47,10 @@ spec:
         memory: 512Mi
     mon:
       limits:
-        cpu: '1'
+        cpu: 500m
         memory: 2Gi
       requests:
-        cpu: '1'
+        cpu: 250m
         memory: 2Gi
     osd:
       limits:

--- a/tests/golden/defaults/rook-ceph/rook-ceph/10_cephcluster_cluster.yaml
+++ b/tests/golden/defaults/rook-ceph/rook-ceph/10_cephcluster_cluster.yaml
@@ -40,11 +40,11 @@ spec:
   resources:
     mgr:
       limits:
-        cpu: '1'
-        memory: 2Gi
+        cpu: 500m
+        memory: 1Gi
       requests:
-        cpu: '1'
-        memory: 2Gi
+        cpu: 250m
+        memory: 512Mi
     mon:
       limits:
         cpu: '1'

--- a/tests/golden/openshift4/rook-ceph/rook-ceph/10_cephcluster_cluster.yaml
+++ b/tests/golden/openshift4/rook-ceph/rook-ceph/10_cephcluster_cluster.yaml
@@ -54,10 +54,10 @@ spec:
         memory: 2Gi
     osd:
       limits:
-        cpu: '6'
+        cpu: '2'
         memory: 5Gi
       requests:
-        cpu: '4'
+        cpu: '2'
         memory: 5Gi
   storage:
     storageClassDeviceSets:

--- a/tests/golden/openshift4/rook-ceph/rook-ceph/10_cephcluster_cluster.yaml
+++ b/tests/golden/openshift4/rook-ceph/rook-ceph/10_cephcluster_cluster.yaml
@@ -47,10 +47,10 @@ spec:
         memory: 512Mi
     mon:
       limits:
-        cpu: '1'
+        cpu: 500m
         memory: 2Gi
       requests:
-        cpu: '1'
+        cpu: 250m
         memory: 2Gi
     osd:
       limits:

--- a/tests/golden/openshift4/rook-ceph/rook-ceph/10_cephcluster_cluster.yaml
+++ b/tests/golden/openshift4/rook-ceph/rook-ceph/10_cephcluster_cluster.yaml
@@ -40,11 +40,11 @@ spec:
   resources:
     mgr:
       limits:
-        cpu: '1'
-        memory: 2Gi
+        cpu: 500m
+        memory: 1Gi
       requests:
-        cpu: '1'
-        memory: 2Gi
+        cpu: 250m
+        memory: 512Mi
     mon:
       limits:
         cpu: '1'


### PR DESCRIPTION
This PR:
- Reduces OSD CPU requests and limits.
   Even the cluster with the heaviest workload barely uses 0.8 cores.
   [Query](https://prometheus-k8s-openshift-monitoring.apps.cloudscale-lpg-2.appuio.cloud/graph?g0.expr=max_over_time%20(node_namespace_pod_container%3Acontainer_cpu_usage_seconds_total%3Asum_irate%7Bnamespace%3D~%22syn-rook-ceph-cluster%22%2Ccontainer%3D%22osd%22%7D%20%5B3h%5D)&g0.tab=0&g0.stacked=0&g0.show_exemplars=0&g0.range_input=9d&g0.end_input=2022-09-08%2013%3A54%3A26&g0.moment_input=2022-09-08%2013%3A54%3A26)
- Reduces MGR CPU/Memory requests and limits.
   The managers are a non critical workload used for monitoring / management plugins and practically unused in our case. 
   [Query](https://prometheus-k8s-openshift-monitoring.apps.cloudscale-lpg-2.appuio.cloud/graph?g0.expr=max_over_time%20(node_namespace_pod_container%3Acontainer_cpu_usage_seconds_total%3Asum_irate%7Bnamespace%3D~%22syn-rook-ceph-cluster%22%2Ccontainer%3D%22mgr%22%7D%20%5B3h%5D)&g0.tab=0&g0.stacked=0&g0.show_exemplars=0&g0.range_input=9d&g0.end_input=2022-09-08%2013%3A55%3A21&g0.moment_input=2022-09-08%2013%3A55%3A21)
- Reduces MON CPU/Memory requests and limits.
   We see very little CPU usage for our biggest cluster. 
   [Query](https://prometheus-k8s-openshift-monitoring.apps.cloudscale-lpg-2.appuio.cloud/graph?g0.expr=max_over_time%20(node_namespace_pod_container%3Acontainer_cpu_usage_seconds_total%3Asum_irate%7Bnamespace%3D~%22syn-rook-ceph-cluster%22%2Ccontainer%3D%22mon%22%7D%20%5B3h%5D)&g0.tab=0&g0.stacked=0&g0.show_exemplars=0&g0.range_input=9d&g0.end_input=2022-09-08%2013%3A55%3A21&g0.moment_input=2022-09-08%2013%3A55%3A21)
- Does NOT reduce MDS CPU limits and requests.
   The active MDS daemon uses a lot of CPU. This most likely relates to file metadata updates when Kubernetes mounts RWX volumes with many small files.
   [Query](https://prometheus-k8s-openshift-monitoring.apps.cloudscale-lpg-2.appuio.cloud/graph?g0.expr=max_over_time%20(node_namespace_pod_container%3Acontainer_cpu_usage_seconds_total%3Asum_irate%7Bnamespace%3D~%22syn-rook-ceph-cluster%22%2Ccontainer%3D%22mds%22%7D%20%5B3h%5D)&g0.tab=0&g0.stacked=0&g0.show_exemplars=0&g0.range_input=9d&g0.end_input=2022-09-08%2013%3A55%3A21&g0.moment_input=2022-09-08%2013%3A55%3A21)
- Does reduce MDS Memory limits and requests to the internally recommended maximum.
  The MDS memory is almost all used for cache. On our heaviest loaded cluster it uses 5.5Gi.
  The recommended minimum is 4Gi.
  [Query](https://prometheus-k8s-openshift-monitoring.apps.cloudscale-lpg-2.appuio.cloud/graph?g0.expr=max_over_time%20(node_namespace_pod_container%3Acontainer_memory_working_set_bytes%7Bnamespace%3D~%22syn-rook-ceph-cluster%22%2Ccontainer%3D%22mds%22%7D%20%5B3h%5D)&g0.tab=0&g0.stacked=0&g0.show_exemplars=0&g0.range_input=9d&g0.end_input=2022-09-08%2013%3A55%3A21&g0.moment_input=2022-09-08%2013%3A55%3A21)

Resource usage has been looked at on LPG2 and cross checked with other clusters.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
