### PR TITLE
Add missing RBAC rule for CephFS `csi-provisioner`

### DIFF
--- a/tests/golden/defaults/rook-ceph/rook-ceph/03_rbac_fixes.yaml
+++ b/tests/golden/defaults/rook-ceph/rook-ceph/03_rbac_fixes.yaml
@@ -1,0 +1,36 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: rook-ceph
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: syn-rook-ceph-cephfs-provisioner-fix
+    name: syn-rook-ceph-cephfs-provisioner-fix
+  name: syn-rook-ceph-cephfs-provisioner-fix
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - nodes
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: rook-ceph
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: syn-rook-ceph-cephfs-provisioner-fix
+    name: syn-rook-ceph-cephfs-provisioner-fix
+  name: syn-rook-ceph-cephfs-provisioner-fix
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: syn-rook-ceph-cephfs-provisioner-fix
+subjects:
+  - kind: ServiceAccount
+    name: rook-csi-cephfs-provisioner-sa
+    namespace: syn-rook-ceph-operator

--- a/tests/golden/openshift4/rook-ceph/rook-ceph/03_rbac_fixes.yaml
+++ b/tests/golden/openshift4/rook-ceph/rook-ceph/03_rbac_fixes.yaml
@@ -1,0 +1,36 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: rook-ceph
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: syn-rook-ceph-cephfs-provisioner-fix
+    name: syn-rook-ceph-cephfs-provisioner-fix
+  name: syn-rook-ceph-cephfs-provisioner-fix
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - nodes
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: rook-ceph
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: syn-rook-ceph-cephfs-provisioner-fix
+    name: syn-rook-ceph-cephfs-provisioner-fix
+  name: syn-rook-ceph-cephfs-provisioner-fix
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: syn-rook-ceph-cephfs-provisioner-fix
+subjects:
+  - kind: ServiceAccount
+    name: rook-csi-cephfs-provisioner-sa
+    namespace: syn-rook-ceph-operator


### PR DESCRIPTION
The Rook Helm chart removed permissions to `get` resource `nodes` from the clusterrole `cephfs-external-provisioner-runner` in commit https://github.com/rook/rook/commit/19f77c617407e6c0e87e5ae9f56ded4ba9955b86.

However, without permission to `get` resource `nodes`, the CephFS `csi-provisioner` container fails to provision new volumes with errors like the following.

```
E0216 14:19:44.814493       1 controller.go:957] error syncing claim "48498303-d89b-4e2d-b629-d52b1d30ec18": failed to get target node: nodes "worker-3b6c" is forbidden: User "system:serviceaccount:syn-rook-ceph-operator:rook-csi-cephfs-provisioner-sa" cannot get resource "nodes" in API group "" at the cluster scope
```

This commit creates an extra clusterrole and clusterrolebinding which grant the CephFS csi-provisioner serviceaccount permission `get` on resource `nodes`.

We've filed an upstream bug, https://github.com/rook/rook/issues/11694, which has been resolved in https://github.com/rook/rook/pull/11697. The root cause for the issue is that the provisioner needs access to the `nodes` resource for volume binding mode `WaitForFirstConsumer`.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
