### PR TITLE
Add component parameter for configuring additional Prometheus rules

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -175,6 +175,17 @@ parameters:
         CephOSDDiskNotResponding:
           for: 5m
 
+      # Supports configuring recording/alerting rules by using the
+      # "record:" and "alert:" prefixes.
+      additionalRules:
+        "alert:RookCephOperatorScaledDown":
+          expr: kube_deployment_spec_replicas{deployment="rook-ceph-operator", namespace="${rook_ceph:namespace}"} == 0
+          for: 1h
+          annotations:
+            summary: rook-ceph operator scaled to 0 for more than 1 hour.
+          labels:
+            severity: warning
+
     node_selector:
       node-role.kubernetes.io/storage: ''
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -410,6 +410,18 @@ The component expects valid partial Prometheus alert rule objects as values.
 
 IMPORTANT: The provided values aren't validated, they're applied to the corresponding upstream alert as-is.
 
+=== `additionalRules`
+
+[horizontal]
+type:: dict
+default:: https://github.com/projectsyn/component-rook-ceph/blob/master/class/defaults.yml[See `class/defaults.yml`]
+
+This parameter allows users to configure additional alerting and recording rules.
+All rules defined in this parameter will be added to rule group `syn-rook-ceph-additional.rules`.
+
+For alerting rules, a runbook URL is injected if annotation `runbook_url` is not already set on the rule.
+The injected runbook URL is derived from the alert name using pattern `pass:[https://hub.syn.tools/rook-ceph/runbooks/{alertname}.html]`.
+
 == `node_selector`
 
 [horizontal]

--- a/tests/golden/defaults/rook-ceph/rook-ceph/40_alertrules.yaml
+++ b/tests/golden/defaults/rook-ceph/rook-ceph/40_alertrules.yaml
@@ -414,11 +414,10 @@ spec:
             syn: 'true'
             syn_component: rook-ceph
             type: ceph_default
-    - name: syn-rook-ceph-additional.alerts
+    - name: syn-rook-ceph-additional.rules
       rules:
-        - alert: SYN_RookCephOperatorScaledDown
+        - alert: RookCephOperatorScaledDown
           annotations:
-            description: TODO
             runbook_url: https://hub.syn.tools/rook-ceph/runbooks/RookCephOperatorScaledDown.html
             summary: rook-ceph operator scaled to 0 for more than 1 hour.
           expr: kube_deployment_spec_replicas{deployment="rook-ceph-operator", namespace="syn-rook-ceph-operator"}

--- a/tests/golden/openshift4/rook-ceph/rook-ceph/40_alertrules.yaml
+++ b/tests/golden/openshift4/rook-ceph/rook-ceph/40_alertrules.yaml
@@ -414,11 +414,10 @@ spec:
             syn: 'true'
             syn_component: rook-ceph
             type: ceph_default
-    - name: syn-rook-ceph-additional.alerts
+    - name: syn-rook-ceph-additional.rules
       rules:
-        - alert: SYN_RookCephOperatorScaledDown
+        - alert: RookCephOperatorScaledDown
           annotations:
-            description: TODO
             runbook_url: https://hub.syn.tools/rook-ceph/runbooks/RookCephOperatorScaledDown.html
             summary: rook-ceph operator scaled to 0 for more than 1 hour.
           expr: kube_deployment_spec_replicas{deployment="rook-ceph-operator", namespace="syn-rook-ceph-operator"}

--- a/tests/openshift4.yml
+++ b/tests/openshift4.yml
@@ -10,8 +10,11 @@ parameters:
         source: https://raw.githubusercontent.com/projectsyn/component-storageclass/v1.0.0/lib/storageclass.libsonnet
         output_path: vendor/lib/storageclass.libsonnet
       - type: https
-        source: https://raw.githubusercontent.com/appuio/component-openshift4-monitoring/v3.1.0/lib/openshift4-monitoring-alert-patching.libsonnet
+        source: https://raw.githubusercontent.com/appuio/component-openshift4-monitoring/v3.5.0/lib/openshift4-monitoring-alert-patching.libsonnet
         output_path: vendor/lib/alert-patching.libsonnet
+      - type: https
+        source: https://raw.githubusercontent.com/appuio/component-openshift4-monitoring/v3.5.0/lib/openshift4-monitoring-prom.libsonnet
+        output_path: vendor/lib/prom.libsonnet
 
   storageclass:
     defaults: {}


### PR DESCRIPTION
This makes use of the new openshift4-monitoring library function introduced in https://github.com/appuio/component-openshift4-monitoring/pull/162


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
