### PR TITLE
Use `rate()` in recording rules

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -185,10 +185,10 @@ parameters:
             summary: rook-ceph operator scaled to 0 for more than 1 hour.
           labels:
             severity: warning
-        "record:ceph_osd_op_w_in_bytes:irate5m":
-          expr: sum(irate(ceph_osd_op_w_in_bytes{}[5m]))
-        "record:ceph_osd_op_r_out_bytes:irate5m":
-          expr: sum(irate(ceph_osd_op_r_out_bytes{}[5m]))
+        "record:ceph_osd_op_w_in_bytes:rate5m":
+          expr: sum(rate(ceph_osd_op_w_in_bytes{}[5m]))
+        "record:ceph_osd_op_r_out_bytes:rate5m":
+          expr: sum(rate(ceph_osd_op_r_out_bytes{}[5m]))
         "record:ceph_pool_objects:sum":
           expr: sum(ceph_pool_objects{})
         "record:ceph_mon_num_sessions:sum":
@@ -209,10 +209,10 @@ parameters:
           expr: avg(rate(ceph_osd_op_w_latency_sum{}[5m]) / rate(ceph_osd_op_w_latency_count{}[5m]) >= 0)
         "record:ceph_osd_op_r_latency:avg5m":
           expr: avg(rate(ceph_osd_op_r_latency_sum{}[5m]) / rate(ceph_osd_op_r_latency_count{}[5m]) >= 0)
-        "record:ceph_osd_op_w:irate5m":
-          expr: sum(irate(ceph_osd_op_w{}[5m]))
-        "record:ceph_osd_op_r:irate5m":
-          expr: sum(irate(ceph_osd_op_r{}[5m]))
+        "record:ceph_osd_op_w:rate5m":
+          expr: sum(rate(ceph_osd_op_w{}[5m]))
+        "record:ceph_osd_op_r:rate5m":
+          expr: sum(rate(ceph_osd_op_r{}[5m]))
 
     node_selector:
       node-role.kubernetes.io/storage: ''

--- a/tests/golden/defaults/rook-ceph/rook-ceph/40_alertrules.yaml
+++ b/tests/golden/defaults/rook-ceph/rook-ceph/40_alertrules.yaml
@@ -437,19 +437,19 @@ spec:
           record: ceph_osd_commit_latency_ms:avg
         - expr: sum(ceph_osd_numpg{})
           record: ceph_osd_numpg:sum
-        - expr: sum(irate(ceph_osd_op_r{}[5m]))
-          record: ceph_osd_op_r:irate5m
+        - expr: sum(rate(ceph_osd_op_r{}[5m]))
+          record: ceph_osd_op_r:rate5m
         - expr: avg(rate(ceph_osd_op_r_latency_sum{}[5m]) / rate(ceph_osd_op_r_latency_count{}[5m])
             >= 0)
           record: ceph_osd_op_r_latency:avg5m
-        - expr: sum(irate(ceph_osd_op_r_out_bytes{}[5m]))
-          record: ceph_osd_op_r_out_bytes:irate5m
+        - expr: sum(rate(ceph_osd_op_r_out_bytes{}[5m]))
+          record: ceph_osd_op_r_out_bytes:rate5m
         - expr: sum(ceph_osd_op_r_out_bytes{})
           record: ceph_osd_op_r_out_bytes:sum
-        - expr: sum(irate(ceph_osd_op_w{}[5m]))
-          record: ceph_osd_op_w:irate5m
-        - expr: sum(irate(ceph_osd_op_w_in_bytes{}[5m]))
-          record: ceph_osd_op_w_in_bytes:irate5m
+        - expr: sum(rate(ceph_osd_op_w{}[5m]))
+          record: ceph_osd_op_w:rate5m
+        - expr: sum(rate(ceph_osd_op_w_in_bytes{}[5m]))
+          record: ceph_osd_op_w_in_bytes:rate5m
         - expr: sum(ceph_osd_op_w_in_bytes{})
           record: ceph_osd_op_w_in_bytes:sum
         - expr: avg(rate(ceph_osd_op_w_latency_sum{}[5m]) / rate(ceph_osd_op_w_latency_count{}[5m])

--- a/tests/golden/openshift4/rook-ceph/rook-ceph/40_alertrules.yaml
+++ b/tests/golden/openshift4/rook-ceph/rook-ceph/40_alertrules.yaml
@@ -437,19 +437,19 @@ spec:
           record: ceph_osd_commit_latency_ms:avg
         - expr: sum(ceph_osd_numpg{})
           record: ceph_osd_numpg:sum
-        - expr: sum(irate(ceph_osd_op_r{}[5m]))
-          record: ceph_osd_op_r:irate5m
+        - expr: sum(rate(ceph_osd_op_r{}[5m]))
+          record: ceph_osd_op_r:rate5m
         - expr: avg(rate(ceph_osd_op_r_latency_sum{}[5m]) / rate(ceph_osd_op_r_latency_count{}[5m])
             >= 0)
           record: ceph_osd_op_r_latency:avg5m
-        - expr: sum(irate(ceph_osd_op_r_out_bytes{}[5m]))
-          record: ceph_osd_op_r_out_bytes:irate5m
+        - expr: sum(rate(ceph_osd_op_r_out_bytes{}[5m]))
+          record: ceph_osd_op_r_out_bytes:rate5m
         - expr: sum(ceph_osd_op_r_out_bytes{})
           record: ceph_osd_op_r_out_bytes:sum
-        - expr: sum(irate(ceph_osd_op_w{}[5m]))
-          record: ceph_osd_op_w:irate5m
-        - expr: sum(irate(ceph_osd_op_w_in_bytes{}[5m]))
-          record: ceph_osd_op_w_in_bytes:irate5m
+        - expr: sum(rate(ceph_osd_op_w{}[5m]))
+          record: ceph_osd_op_w:rate5m
+        - expr: sum(rate(ceph_osd_op_w_in_bytes{}[5m]))
+          record: ceph_osd_op_w_in_bytes:rate5m
         - expr: sum(ceph_osd_op_w_in_bytes{})
           record: ceph_osd_op_w_in_bytes:sum
         - expr: avg(rate(ceph_osd_op_w_latency_sum{}[5m]) / rate(ceph_osd_op_w_latency_count{}[5m])


### PR DESCRIPTION
With `irate()` there's a chance that the recording rules are flatlined at 0 even when there's bursts of activity on clusters with low overall utilization, if the bursts fall between the evaluation points.

Follow-up to #128 


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
