### PR TITLE
Ignore `kubectl` error output when extracting current holder pod generation

### DIFF
--- a/component/restart-holder-ds.libsonnet
+++ b/component/restart-holder-ds.libsonnet
@@ -89,11 +89,19 @@ local daemonset = kube.DaemonSet('syn-holder-updater') {
         'non-daemonset pods are running on the node) and then deletes any ' +
         'outdated csi holder pods. Outdated holder pods are identified by ' +
         'comparing the DaemonSet generation with the pod generation.',
+      // set sync wave 10 for the daemonset to ensure that the ConfigMap is
+      // updated first.
+      'argocd.argoproj.io/sync-wave': '10',
     },
     namespace: params.namespace,
   },
   spec+: {
     template+: {
+      metadata+: {
+        annotations+: {
+          'script-checksum': std.md5(script),
+        },
+      },
       spec+: {
         serviceAccountName: serviceaccount.metadata.name,
         containers_: {

--- a/component/restart-holder-ds.libsonnet
+++ b/component/restart-holder-ds.libsonnet
@@ -39,8 +39,11 @@ local script = |||
   while true; do
     # assumption: holder plugin daemonset is called
     # `csi-cephfsplugin-holder-${cephcluster:name}`
-    cephfs_holder_wanted_gen=$(kubectl get ds csi-cephfsplugin-holder-%(cephcluster_name)s -ojsonpath='{.metadata.generation}')
-    rbd_holder_wanted_gen=$(kubectl get ds csi-rbdplugin-holder-%(cephcluster_name)s -ojsonpath='{.metadata.generation}')
+    # note: we don't care about the value of the variable if the daemonset
+    # isn't there, since we'll check for pods in a K8s `List` which will
+    # simply be empty if the plugin isn't enabled.
+    cephfs_holder_wanted_gen=$(kubectl get ds csi-cephfsplugin-holder-%(cephcluster_name)s -ojsonpath='{.metadata.generation}' 2>/dev/null)
+    rbd_holder_wanted_gen=$(kubectl get ds csi-rbdplugin-holder-%(cephcluster_name)s -ojsonpath='{.metadata.generation}' 2>/dev/null)
     needs_update=$( (\
       kubectl get pods -l app=csi-cephfsplugin-holder --field-selector spec.nodeName=${NODE_NAME} -ojson |\
         jq --arg wanted_gen ${cephfs_holder_wanted_gen} \

--- a/tests/golden/cephfs/rook-ceph/rook-ceph/50_restart_holder_ds.yaml
+++ b/tests/golden/cephfs/rook-ceph/rook-ceph/50_restart_holder_ds.yaml
@@ -103,6 +103,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   annotations:
+    argocd.argoproj.io/sync-wave: '10'
     syn.tools/description: DaemonSet which waits for node to be drained (by waiting
       until no non-daemonset pods are running on the node) and then deletes any outdated
       csi holder pods. Outdated holder pods are identified by comparing the DaemonSet
@@ -123,7 +124,8 @@ spec:
       name: syn-holder-updater
   template:
     metadata:
-      annotations: {}
+      annotations:
+        script-checksum: 488da91788ef6e501cece9d3d67ff8b0
       labels:
         app.kubernetes.io/component: rook-ceph
         app.kubernetes.io/managed-by: commodore

--- a/tests/golden/cephfs/rook-ceph/rook-ceph/50_restart_holder_ds.yaml
+++ b/tests/golden/cephfs/rook-ceph/rook-ceph/50_restart_holder_ds.yaml
@@ -57,8 +57,11 @@ data:
     while true; do
       # assumption: holder plugin daemonset is called
       # `csi-cephfsplugin-holder-${cephcluster:name}`
-      cephfs_holder_wanted_gen=$(kubectl get ds csi-cephfsplugin-holder-cluster -ojsonpath='{.metadata.generation}')
-      rbd_holder_wanted_gen=$(kubectl get ds csi-rbdplugin-holder-cluster -ojsonpath='{.metadata.generation}')
+      # note: we don't care about the value of the variable if the daemonset
+      # isn't there, since we'll check for pods in a K8s `List` which will
+      # simply be empty if the plugin isn't enabled.
+      cephfs_holder_wanted_gen=$(kubectl get ds csi-cephfsplugin-holder-cluster -ojsonpath='{.metadata.generation}' 2>/dev/null)
+      rbd_holder_wanted_gen=$(kubectl get ds csi-rbdplugin-holder-cluster -ojsonpath='{.metadata.generation}' 2>/dev/null)
       needs_update=$( (\
         kubectl get pods -l app=csi-cephfsplugin-holder --field-selector spec.nodeName=${NODE_NAME} -ojson |\
           jq --arg wanted_gen ${cephfs_holder_wanted_gen} \

--- a/tests/golden/defaults/rook-ceph/rook-ceph/50_restart_holder_ds.yaml
+++ b/tests/golden/defaults/rook-ceph/rook-ceph/50_restart_holder_ds.yaml
@@ -103,6 +103,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   annotations:
+    argocd.argoproj.io/sync-wave: '10'
     syn.tools/description: DaemonSet which waits for node to be drained (by waiting
       until no non-daemonset pods are running on the node) and then deletes any outdated
       csi holder pods. Outdated holder pods are identified by comparing the DaemonSet
@@ -123,7 +124,8 @@ spec:
       name: syn-holder-updater
   template:
     metadata:
-      annotations: {}
+      annotations:
+        script-checksum: 488da91788ef6e501cece9d3d67ff8b0
       labels:
         app.kubernetes.io/component: rook-ceph
         app.kubernetes.io/managed-by: commodore

--- a/tests/golden/defaults/rook-ceph/rook-ceph/50_restart_holder_ds.yaml
+++ b/tests/golden/defaults/rook-ceph/rook-ceph/50_restart_holder_ds.yaml
@@ -57,8 +57,11 @@ data:
     while true; do
       # assumption: holder plugin daemonset is called
       # `csi-cephfsplugin-holder-${cephcluster:name}`
-      cephfs_holder_wanted_gen=$(kubectl get ds csi-cephfsplugin-holder-cluster -ojsonpath='{.metadata.generation}')
-      rbd_holder_wanted_gen=$(kubectl get ds csi-rbdplugin-holder-cluster -ojsonpath='{.metadata.generation}')
+      # note: we don't care about the value of the variable if the daemonset
+      # isn't there, since we'll check for pods in a K8s `List` which will
+      # simply be empty if the plugin isn't enabled.
+      cephfs_holder_wanted_gen=$(kubectl get ds csi-cephfsplugin-holder-cluster -ojsonpath='{.metadata.generation}' 2>/dev/null)
+      rbd_holder_wanted_gen=$(kubectl get ds csi-rbdplugin-holder-cluster -ojsonpath='{.metadata.generation}' 2>/dev/null)
       needs_update=$( (\
         kubectl get pods -l app=csi-cephfsplugin-holder --field-selector spec.nodeName=${NODE_NAME} -ojson |\
           jq --arg wanted_gen ${cephfs_holder_wanted_gen} \

--- a/tests/golden/openshift4/rook-ceph/rook-ceph/50_restart_holder_ds.yaml
+++ b/tests/golden/openshift4/rook-ceph/rook-ceph/50_restart_holder_ds.yaml
@@ -103,6 +103,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   annotations:
+    argocd.argoproj.io/sync-wave: '10'
     syn.tools/description: DaemonSet which waits for node to be drained (by waiting
       until no non-daemonset pods are running on the node) and then deletes any outdated
       csi holder pods. Outdated holder pods are identified by comparing the DaemonSet
@@ -123,7 +124,8 @@ spec:
       name: syn-holder-updater
   template:
     metadata:
-      annotations: {}
+      annotations:
+        script-checksum: 488da91788ef6e501cece9d3d67ff8b0
       labels:
         app.kubernetes.io/component: rook-ceph
         app.kubernetes.io/managed-by: commodore

--- a/tests/golden/openshift4/rook-ceph/rook-ceph/50_restart_holder_ds.yaml
+++ b/tests/golden/openshift4/rook-ceph/rook-ceph/50_restart_holder_ds.yaml
@@ -57,8 +57,11 @@ data:
     while true; do
       # assumption: holder plugin daemonset is called
       # `csi-cephfsplugin-holder-${cephcluster:name}`
-      cephfs_holder_wanted_gen=$(kubectl get ds csi-cephfsplugin-holder-cluster -ojsonpath='{.metadata.generation}')
-      rbd_holder_wanted_gen=$(kubectl get ds csi-rbdplugin-holder-cluster -ojsonpath='{.metadata.generation}')
+      # note: we don't care about the value of the variable if the daemonset
+      # isn't there, since we'll check for pods in a K8s `List` which will
+      # simply be empty if the plugin isn't enabled.
+      cephfs_holder_wanted_gen=$(kubectl get ds csi-cephfsplugin-holder-cluster -ojsonpath='{.metadata.generation}' 2>/dev/null)
+      rbd_holder_wanted_gen=$(kubectl get ds csi-rbdplugin-holder-cluster -ojsonpath='{.metadata.generation}' 2>/dev/null)
       needs_update=$( (\
         kubectl get pods -l app=csi-cephfsplugin-holder --field-selector spec.nodeName=${NODE_NAME} -ojson |\
           jq --arg wanted_gen ${cephfs_holder_wanted_gen} \


### PR DESCRIPTION
This suppresses error messages like the following on installations which only have cephfs or rbd enabled, but not both.

```
Error from server (NotFound): daemonsets.apps "csi-rbdplugin-holder-cluster" not found
```

We don't care about the resulting value of the generation variable when the daemonset is missing, since we'll check an empty pod list for outdated pods in that case.

Additionally, we ensure that the holder-update DaemonSet pods are restarted when we modify the script by adding the script's md5sum as an annotation in the pod template.

Follow-up for #154 

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
