### PR TITLE
Fix `cephcsi` image override

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -263,7 +263,8 @@ parameters:
         enableGrpcMetrics: true
         enableLiveness: true
         cephcsi:
-          image: ${rook_ceph:images:cephcsi:registry}/${rook_ceph:images:cephcsi:image}:${rook_ceph:images:cephcsi:tag}
+          repository: ${rook_ceph:images:cephcsi:registry}/${rook_ceph:images:cephcsi:image}
+          tag: ${rook_ceph:images:cephcsi:tag}
       pspEnable: false
 
     toolbox:

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -490,7 +490,7 @@ The Helm values to use when rendering the rook-ceph operator Helm chart.
 
 A few Helm values are configured based on other component parameters by default:
 
-* The data in parameter `images` is used to set the `image.repository`, `image.tag`, and `csi.cephcsi.image` Helm values
+* The data in parameter `images` is used to set the `image.repository`, `image.tag`, `csi.cephcsi.repository`, and `csi.cephcsi.tag` Helm values
 * The value of `node_selector` is used to set Helm value `nodeSelector`
 * The value of `tolerations` is used to set Helm value `tolerations`
 * The component ensures that `hostpathRequiresPrivileged` is enabled on OpenShift 4 regardless of the contents of the Helm value.


### PR DESCRIPTION
Rook `v1.14` changed the way `cephcsi` images are overridden and we accidentally already released a new `cephcsi` version in `v8`. Note: This change is a no-op together with https://github.com/projectsyn/component-rook-ceph/pull/144.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
