### PR TITLE
Fix operator deployment ROOK_HOSTPATH_REQUIRES_PRIVILEGED on OKE

### DIFF
--- a/postprocess/patch_operator_deployment.jsonnet
+++ b/postprocess/patch_operator_deployment.jsonnet
@@ -8,7 +8,7 @@ local params = inv.parameters.rook_ceph;
 // Respect user-provided configuration via `operator_helm_values` on
 // distributions other than OCP4.
 local hostpath_requires_privileged =
-  if inv.parameters.facts.distribution == 'openshift4' then
+  if std.member([ 'openshift4', 'oke' ], inv.parameters.facts.distribution) then
     true
   else
     com.getValueOrDefault(


### PR DESCRIPTION
On OKE the deployment of the operator need to set the following env var: `ROOK_HOSTPATH_REQUIRES_PRIVILEGED=true`.




## Checklist

- [ ] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [ ] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [ ] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
