### PR TITLE
Update `rook-ceph-osd` Role to grant `GET secrets`

### DIFF
--- a/component/cephcluster.libsonnet
+++ b/component/cephcluster.libsonnet
@@ -41,6 +41,15 @@ local roles =
           resources: [ 'cephclusters', 'cephclusters/finalizers' ],
           verbs: [ 'get', 'list', 'create', 'update', 'delete' ],
         },
+        // Required for OSD prepare jobs with recent Rook versions.
+        // NOTE(sg): I've not fully determined when/how this changed, but we
+        // noticed on a test cluster where the storage cluster was provisioned
+        // with Rook 1.18.
+        {
+          apiGroups: [ '' ],
+          resources: [ 'secrets' ],
+          verbs: [ 'get' ],
+        },
       ],
     },
     mgr: kube.Role('rook-ceph-mgr') {

--- a/tests/golden/cephfs/rook-ceph/rook-ceph/10_cephcluster_rbac.yaml
+++ b/tests/golden/cephfs/rook-ceph/rook-ceph/10_cephcluster_rbac.yaml
@@ -173,6 +173,12 @@ rules:
       - create
       - update
       - delete
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/tests/golden/defaults/rook-ceph/rook-ceph/10_cephcluster_rbac.yaml
+++ b/tests/golden/defaults/rook-ceph/rook-ceph/10_cephcluster_rbac.yaml
@@ -173,6 +173,12 @@ rules:
       - create
       - update
       - delete
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/tests/golden/openshift4/rook-ceph/rook-ceph/10_cephcluster_rbac.yaml
+++ b/tests/golden/openshift4/rook-ceph/rook-ceph/10_cephcluster_rbac.yaml
@@ -196,6 +196,12 @@ rules:
       - create
       - update
       - delete
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/tests/golden/rbd-extra-storageclass/rook-ceph/rook-ceph/10_cephcluster_rbac.yaml
+++ b/tests/golden/rbd-extra-storageclass/rook-ceph/rook-ceph/10_cephcluster_rbac.yaml
@@ -196,6 +196,12 @@ rules:
       - create
       - update
       - delete
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
This permission is required by the OSD prepare jobs for encrypted OSDs that use K8s secrets to store the encryption keys.

Note that we've not fully determined when/how this changed (since previously OSD prepare jobs for encrypted OSDs worked fine without this permission), but we noticed that the OSD prepare jobs were failing on a test cluster where the storage cluster was provisioned with Rook 1.18.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.


<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
